### PR TITLE
configuring redirect for netlify deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,16 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 
 ## Available Scripts
 
-In the project directory, you can run:
+To run locally on your pc:
+1. clone the project
+2. in /src/App.tsx replace the fetch url link ('/api/astros.json') in the useEffect with 'http://api.open-notify.org/astros.json'. Note that this is only for running locally, to run on a hosted platform leave as is i.e '/api/astros.json'
+3. in the root of your project run the command below:
 
 ### `npm start`
 
 Runs the app in the development mode.\
 Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+
 
 The page will reload if you make edits.\
 You will also see any lint errors in the console.

--- a/public/_redirect
+++ b/public/_redirect
@@ -1,1 +1,0 @@
-/api/* http://api.open-notify.org/:splat 200

--- a/src/App.css
+++ b/src/App.css
@@ -28,3 +28,12 @@
   position: relative;
 }
 
+
+@media only screen and (max-width: 800px) {
+  .title {
+    font-size: 1.3rem;
+  }
+  .custom-input {
+    width: 20rem;
+  }
+}


### PR DESCRIPTION
configuring redirect to allow http api calls over netlify's https